### PR TITLE
Allow connecting to MySQL without specifying a database

### DIFF
--- a/src/com/huskehhh/mysql/mysql/MySQL.java
+++ b/src/com/huskehhh/mysql/mysql/MySQL.java
@@ -19,9 +19,25 @@ public class MySQL extends Database {
 	private final String port;
 	private final String hostname;
 
-
 	/**
 	 * Creates a new MySQL instance
+	 *
+	 * @param hostname
+	 *            Name of the host
+	 * @param port
+	 *            Port number
+	 * @param username
+	 *            Username
+	 * @param password
+	 *            Password
+	 */
+	public MySQL(String hostname, String port, String username,
+			String password) {
+		this(hostname, port, null, username, password);
+	}
+
+	/**
+	 * Creates a new MySQL instance for a specific database
 	 *
 	 * @param hostname
 	 *            Name of the host

--- a/src/com/huskehhh/mysql/mysql/MySQL.java
+++ b/src/com/huskehhh/mysql/mysql/MySQL.java
@@ -49,9 +49,15 @@ public class MySQL extends Database {
 		if (checkConnection()) {
 			return connection;
 		}
+		
+		String connectionURL = "jdbc:mysql://"
+				+ this.hostname + ":" + this.port;
+		if (database != null) {
+			connectionURL = connectionURL + "/" + this.database;
+		}
+		
 		Class.forName("com.mysql.jdbc.Driver");
-		connection = DriverManager.getConnection("jdbc:mysql://"
-				+ this.hostname + ":" + this.port + "/" + this.database,
+		connection = DriverManager.getConnection(connectionURL,
 				this.user, this.password);
 		return connection;
 	}


### PR DESCRIPTION
Currently, we have to specify a database when connecting using MySQL, which isn't necessary. We can also connect to MySQL without specifying the database. The SQL queries will then need to specify the database, e.g. use "SELECT * FROM database.table;" instead of "SELECT * FROM table;".
This allows the user to connect to multiple databases using one instance of the MySQL class by specifying the database in the query rather than in the URL.